### PR TITLE
Dbp 550 standardize dockerfile structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE=nginx:1.25-alpine
 # Build Stage
 FROM $BASE_IMAGE_BUILDER as build
 
-RUN apk add openjdk17-jre=17.0.*
+RUN apk add openjdk17-jre=17.0.10_*
 
 WORKDIR /app
 COPY tsconfig*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ FROM $BASE_IMAGE_BUILDER as build
 #To maintain stability, we install OpenJDK without running apk upgrade. 
 #This limits the changes in Docker image to just adding OpenJDK, rather than potentially updating all packages.
 
-RUN apk add openjdk17-jre
+#SPSH-242-generate-api-client-in-ci
+#RUN apk update \
+# && apk add openjdk17-jre
+#latest version : 17.01-2024
+RUN apk add openjdk17-jre=17.0.10_p7-r0
 
 WORKDIR /app
 COPY tsconfig*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 
-ARG BASE_IMAGE_BUILDER=node:21.6.0-alpine3.19
+ARG BASE_IMAGE_BUILDER=node:21.6.0-alpine3.18
 ARG BASE_IMAGE=nginx:1.25-alpine
 
 # Build Stage
 FROM $BASE_IMAGE_BUILDER as build
 
-RUN apk add openjdk17-jre=17.0.10_*
+RUN apk add openjdk17-jre=17.0.10_p7-r0
 
 WORKDIR /app
 COPY tsconfig*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,15 @@ ARG BASE_IMAGE=nginx:1.25-alpine
 # Build Stage
 FROM $BASE_IMAGE_BUILDER as build
 
-# This comment based on Branch  SPSH-242-generate-api-client-in-ci ( can be removed after review)
-# OpenJDK 17,is a specific requirement for running the OpenAPI code generator
-# Avoiding apk upgrade in Build Stage:
-#To maintain stability, we install OpenJDK without running apk upgrade. 
-#This limits the changes in Docker image to just adding OpenJDK, rather than potentially updating all packages.
 
-#SPSH-242-generate-api-client-in-ci
+# OpenJDK 17,is a specific requirement for running the OpenAPI code generator(SPSH-242-generate-api-client-in-ci)
+# Avoiding apk update  in Build Stage:
 #RUN apk update \
 # && apk add openjdk17-jre
-#latest version : 17.01-2024
+#To maintain stability, we install OpenJDK without running apk update. This limits the changes in Docker image to just adding OpenJDK, rather than potentially updating all packages.
+#Pin the OpenJDK 17 JRE version to the latest deployed version
+#https://pkgs.alpinelinux.org/package/edge/community/x86_64/openjdk17-jre-headless
+
 RUN apk add openjdk17-jre=17.0.10_p7-r0
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
 
-ARG BASE_IMAGE_BUILDER=node:21.6.0-alpine3.19
+ARG BASE_IMAGE_BUILDER=node:21.6.1-alpine3.19
 ARG BASE_IMAGE=nginx:1.25-alpine
 
 # Build Stage
 FROM $BASE_IMAGE_BUILDER as build
 
-
-# OpenJDK 17,is a specific requirement for running the OpenAPI code generator(SPSH-242-generate-api-client-in-ci)
-# Avoiding apk update  in Build Stage:
-#RUN apk update \
-# && apk add openjdk17-jre
-#To maintain stability, we install OpenJDK without running apk update. This limits the changes in Docker image to just adding OpenJDK, rather than potentially updating all packages.
-#Pin the OpenJDK 17 JRE version to the latest deployed version
-#https://pkgs.alpinelinux.org/package/edge/community/x86_64/openjdk17-jre-headless
-
-RUN apk add openjdk17-jre=17.0.10_p7-r0
+RUN apk add openjdk17-jre=17.0.*
 
 WORKDIR /app
 COPY tsconfig*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-ARG BASE_IMAGE_BUILDER=node:20.9.0-alpine3.18
+
+ARG BASE_IMAGE_BUILDER=node:21.6.0-alpine3.19
 ARG BASE_IMAGE=nginx:1.25-alpine
-FROM $BASE_IMAGE_BUILDER as scaffold
+
+# Build Stage
+FROM $BASE_IMAGE_BUILDER as build
 
 
 WORKDIR /app
-
 COPY tsconfig*.json ./
 COPY package*.json ./
 COPY vite*.ts ./
@@ -15,8 +17,9 @@ COPY src/ src/
 RUN npm install
 RUN npm run build
 
+# Deployment Stage
 FROM $BASE_IMAGE as deployment
 
-COPY --from=scaffold /app/dist/ /usr/share/nginx/html/
+COPY --from=build /app/dist/ /usr/share/nginx/html/
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx-vue.conf /etc/nginx/conf.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ ARG BASE_IMAGE=nginx:1.25-alpine
 # Build Stage
 FROM $BASE_IMAGE_BUILDER as build
 
+# This comment based on Branch  SPSH-242-generate-api-client-in-ci ( can be removed after review)
+# OpenJDK 17,is a specific requirement for running the OpenAPI code generator
+# Avoiding apk upgrade in Build Stage:
+#To maintain stability, we install OpenJDK without running apk upgrade. 
+#This limits the changes in Docker image to just adding OpenJDK, rather than potentially updating all packages.
+
+RUN apk add openjdk17-jre
 
 WORKDIR /app
 COPY tsconfig*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG BASE_IMAGE_BUILDER=node:21.6.1-alpine3.19
+ARG BASE_IMAGE_BUILDER=node:21.6.0-alpine3.19
 ARG BASE_IMAGE=nginx:1.25-alpine
 
 # Build Stage


### PR DESCRIPTION
#Description

This pull request introduces essential improvements to our Dockerfiles within the SPSH context, aiming to resolve inconsistencies in naming conventions, base image versions, and package update strategies. The specific changes are as follows:

Uniform Naming for Build and Deployment Stages: In all Dockerfiles, we have standardized the naming for the build and deployment stages. The build stage is now uniformly referred to as build in the FROM * AS build statement. Similarly, the deployment stage is consistently named deployment in the FROM * AS deployment statement. This change simplifies the understanding of the Dockerfile stages and aids in the quick identification of each stage's purpose.
