### PR TITLE
dbp-608-Fixed commit SHA for external Jobs

### DIFF
--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
-        - uses: actions/setup-java@v4
+        - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93  #v4.0.0
           with:
             distribution: 'oracle' # See 'Supported distributions' for available options
             java-version: '21'


### PR DESCRIPTION
For external jobs, it is recommended to use fixed commit SHA references.

TODO:

Identify all external jobs currently referenced in our CI/CD workflows.
Update the workflow configurations to reference the external jobs using their respective commit SHAs instead of semantic versions.
AC:

All references to external jobs in the CI/CD workflows must use a fixed commit SHA.
# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.