### PR TITLE
SPSH-477-firefox-dialog-pwReset

### DIFF
--- a/src/components/admin/PasswordReset.vue
+++ b/src/components/admin/PasswordReset.vue
@@ -83,9 +83,11 @@
             </v-row>
             <v-row class="text-body bold px-md-16">
               <v-col>
-                <p data-testid="password-reset-info-text">
-                  {{ resetPasswordInformationMessage }}
-                </p>
+                <span
+                  class="preserve-line-breaks"
+                  data-testid="password-reset-info-text"
+                  >{{ resetPasswordInformationMessage }}</span
+                >
               </v-col>
             </v-row>
             <v-row>
@@ -133,4 +135,8 @@
   </v-dialog>
 </template>
 
-<style></style>
+<style>
+  .preserve-line-breaks {
+    white-space: pre-wrap; /* CSS property to preserve whitespaces and line breaks */
+  }
+</style>

--- a/src/components/admin/PasswordReset.vue
+++ b/src/components/admin/PasswordReset.vue
@@ -76,21 +76,16 @@
                 <v-icon icon="mdi-alert"></v-icon>
               </v-col>
               <v-col>
-                <span
-                  class="preserve-line-breaks"
-                  data-testid="error-text"
-                >
+                <p data-testid="error-text">
                   {{ errorMessage || errorCode }}
-                </span>
+                </p>
               </v-col>
             </v-row>
             <v-row class="text-body bold px-md-16">
               <v-col>
-                <span
-                  class="preserve-line-breaks"
-                  data-testid="password-reset-info-text"
-                  >{{ resetPasswordInformationMessage }}</span
-                >
+                <p data-testid="password-reset-info-text">
+                  {{ resetPasswordInformationMessage }}
+                </p>
               </v-col>
             </v-row>
             <v-row>
@@ -138,8 +133,4 @@
   </v-dialog>
 </template>
 
-<style>
-  .preserve-line-breaks {
-    white-space: pre-wrap; /* CSS property to preserve whitespaces and line breaks */
-  }
-</style>
+<style></style>

--- a/src/components/admin/PasswordReset.vue
+++ b/src/components/admin/PasswordReset.vue
@@ -76,9 +76,12 @@
                 <v-icon icon="mdi-alert"></v-icon>
               </v-col>
               <v-col>
-                <p data-testid="error-text">
+                <span
+                  class="preserve-line-breaks"
+                  data-testid="error-text"
+                >
                   {{ errorMessage || errorCode }}
-                </p>
+                </span>
               </v-col>
             </v-row>
             <v-row class="text-body bold px-md-16">

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -17,7 +17,7 @@
   @media (min-width: 1280px) {
     .v-container {
       max-width: 1200px - 320px;
-      margin-bottom: 240px;
+      margin-bottom: 300px;
     }
   }
 

--- a/src/styles/components/dialog.scss
+++ b/src/styles/components/dialog.scss
@@ -1,6 +1,10 @@
 .v-dialog {
   max-width: 1000px;
 
+  .v-card-text p {
+    white-space: pre-wrap;
+  }
+
   @media only screen and (max-width: 400px) {
     .v-btn {
       width: auto;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -10,5 +10,6 @@
   $field-input-padding-top: 10px,
   $input-control-height: 42px,
   $list-color: #001e49,
-  $selection-control-color: #001e49
+  $selection-control-color: #001e49,
+  $table-color: #001e49
 );


### PR DESCRIPTION
# Description

- Switched from `<p>` to `<span>` since firefox apparently can't handle it's responsiveness inside a v-dialog or v-col...
- More bottom margin for the admin layout since 240px is not enough on firefox for the Ergebnislisten.
- Overriding vuetify variable for the table to control the color.
## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.