### PR TITLE
DBP-706 Only release the Helm chart if the image was successfully pushed

### DIFF
--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -106,6 +106,7 @@ jobs:
 
     needs: 
       - select_helm_version_generation_and_image_tag_generation
+      - build_image_on_push
     secrets: inherit
     with:
       chart_name: schulportal-client


### PR DESCRIPTION
# Description
If we upload the Helm chart but image building failed we get a broken Helm chart that references a non-existent image, if this happens on main, it breaks deployments for branches in the other repos. 
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.