### PR TITLE
spsh 710 changed translation strings to only use benutzer in ui

### DIFF
--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -105,9 +105,9 @@
       "status": "Status"
     },
     "personenkontext": {
-      "creationErrorText": "Bei der Zuordnung des Personenkontextes ist ein Fehler aufgetreten. Bitte prüfen Sie die Zuordnungen an der Person.",
+      "creationErrorText": "Bei der Zuordnung des Personenkontextes ist ein Fehler aufgetreten. Bitte prüfen Sie die Zuordnungen am Benutzer.",
       "errors": {
-        "GLEICHE_ROLLE_AN_KLASSE_WIE_SCHULE": "Mindestens eine Rolle der Person ist an der Schule nicht bekannt.",
+        "GLEICHE_ROLLE_AN_KLASSE_WIE_SCHULE": "Mindestens eine Rolle des Benutzers ist an der Schule nicht bekannt.",
         "NUR_LEHR_UND_LERN_AN_KLASSE": "Nur Schüler dürfen einer Klasse zugeordnet werden.",
         "PERSONENKONTEXT_SPECIFICATION_ERROR": "Die Zuordnung konnte nicht angelegt werden."
       }
@@ -133,8 +133,8 @@
       "mappingFrontBackEnd": {
         "systemrechte": {
           "ROLLEN_VERWALTEN": "Darf Rollen verwalten",
-          "PERSONEN_SOFORT_LOESCHEN": "Darf Personen sofort löschen",
-          "PERSONEN_VERWALTEN": "Darf Personen verwalten",
+          "PERSONEN_SOFORT_LOESCHEN": "Darf Benutzer sofort löschen",
+          "PERSONEN_VERWALTEN": "Darf Benutzer verwalten",
           "SCHULEN_VERWALTEN": "Darf Schulen verwalten",
           "KLASSEN_VERWALTEN": "Darf Klassen verwalten",
           "SCHULTRAEGER_VERWALTEN": "Darf Schulträger verwalten"


### PR DESCRIPTION
# Description
changed translation strings to only use "benutzer" in ui

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-710

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.