### PR TITLE
spsh 784 translations for dropdown close/open hover texts

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,27 +1,21 @@
 import { createI18n, type DefaultLocaleMessageSchema } from 'vue-i18n';
 import * as deDE from '../locales/de-DE.json';
+// @ts-ignore
+// eslint-disable-next-line import/extensions
+import vuetifyDeMessages from 'vuetify/lib/locale/de.mjs';
 
 function loadLocaleMessages(): { [x: string]: DefaultLocaleMessageSchema } {
   const messages: { [x: string]: DefaultLocaleMessageSchema } = {
-    de: deDE,
+    de: { $vuetify: vuetifyDeMessages, ...deDE },
   };
 
   return messages;
 }
 
-const messages: { [x: string]: DefaultLocaleMessageSchema } = {
-  de: {
-    ...loadLocaleMessages()['de'],
-    $vuetify: {
-      close: 'Schließen',
-      open: 'Öffnen',
-    },
-  },
-};
 
 export default createI18n({
   fallbackLocale: 'de',
   legacy: false,
   locale: 'de',
-  messages,
+  messages: loadLocaleMessages(),
 });

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -9,9 +9,19 @@ function loadLocaleMessages(): { [x: string]: DefaultLocaleMessageSchema } {
   return messages;
 }
 
+const messages: { [x: string]: DefaultLocaleMessageSchema } = {
+  de: {
+    ...loadLocaleMessages()['de'],
+    $vuetify: {
+      close: 'Schließen',
+      open: 'Öffnen',
+    },
+  },
+};
+
 export default createI18n({
   fallbackLocale: 'de',
   legacy: false,
   locale: 'de',
-  messages: loadLocaleMessages(),
+  messages,
 });

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,4 +1,7 @@
 import { createVuetify, type ThemeDefinition, type VuetifyOptions } from 'vuetify';
+import { createVueI18nAdapter } from 'vuetify/locale/adapters/vue-i18n';
+import { useI18n } from 'vue-i18n';
+import i18n from '@/plugins/i18n';
 import '@mdi/font/css/materialdesignicons.css';
 import { aliases, mdi } from 'vuetify/iconsets/mdi';
 import '@/styles/main.scss';
@@ -29,6 +32,9 @@ const vuetifyConfig: VuetifyOptions = {
     sets: {
       mdi,
     },
+  },
+  locale: {
+    adapter: createVueI18nAdapter({ i18n, useI18n }),
   },
   theme: {
     cspNonce,


### PR DESCRIPTION
# Description
configured vuetify and i18n to merge translations

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-784
https://github.com/dBildungsplattform/schulportal-testautomatisierung/pull/40

## Notes
vuetify translations should only use overriden messages or we have to implement all internal translations inside new config
-> see comment in ticket


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.