### PR TITLE
SPSH-1174: Fix condition for displaying missing KoPers-Nr in user profile

### DIFF
--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -186,7 +186,7 @@
         testIdValue: 'userName-value',
       });
 
-    if (!hasKoPersMerkmal.value) return data;
+    if (!personInfoStore.personInfo.person.personalnummer && !hasKoPersMerkmal.value) return data;
     data.push({
       label: t('profile.koPersNummer'),
       labelAbbr: t('profile.koPersNummerAbbr'),

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -25,7 +25,7 @@
   type LabelValue = {
     label: string;
     labelAbbr?: string;
-    value: string;
+    value: string | null;
     type?: ItemType;
     testIdLabel: string;
     testIdValue: string;
@@ -186,7 +186,7 @@
         testIdValue: 'userName-value',
       });
 
-    if (!(personInfoStore.personInfo.person.personalnummer && hasKoPersMerkmal.value)) return data;
+    if (!hasKoPersMerkmal.value) return data;
     data.push({
       label: t('profile.koPersNummer'),
       labelAbbr: t('profile.koPersNummerAbbr'),


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

- https://ticketsystem.dbildungscloud.de/browse/SPSH-1174
 
## Notes

Fixes issue causing KoPers-Nr missing warning not being displayed in user's own profile when a KoPers-Nr is required.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.