### PR TITLE
DBP-1084-rollout-to-namespaces-do-not-delete-dbs

### DIFF
--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -128,7 +128,7 @@ jobs:
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
-      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}
       # database_recreation: "true" # to force database recreation this has be set to true
     secrets: inherit
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -110,13 +110,13 @@ jobs:
 
   branch_meta:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/get-branch-meta.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/get-branch-meta.yml@6
 
   create_branch_identifier:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs:
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -141,7 +141,7 @@ jobs:
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -53,7 +53,7 @@ jobs:
       packages: write
       security-events: write
       contents: read
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/image-publish-trivy.yaml@DBP-1179-spsh-image-tag-generation # todo: change to new version
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/image-publish-trivy.yaml@7
     with:
       image_name: 'schulportal-client'
       run_trivy_scan: true

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -44,37 +44,9 @@ jobs:
       contents: read
     secrets: inherit
 
-  determine_image_tag_and_chart_version:
-    name: "Determine image tag and chart version from branch name"
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
-      chart_version: ${{ steps.create_image_tag.outputs.chart_version }}
-    steps:
-      - id: create_image_tag
-        run: |
-          timestamp=`echo $(date +'%Y%m%d-%H%M')`
-          regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
-          regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
-          if [[ $GITHUB_REF_NAME =~ $regex_long ]]; then
-            tag="${BASH_REMATCH[1]}"
-            chart_version="0.0.0-$(echo ${tag} | tr [A-Z] [a-z])-${timestamp}"
-          elif [[ $GITHUB_REF_NAME =~ $regex_short ]]; then
-            tag="${BASH_REMATCH[1]}"
-            chart_version="0.0.0-$(echo ${tag} | tr [A-Z] [a-z])-${timestamp}"
-          elif [[ "${{ github.ref_name }}" != 'main' ]]; then
-            tag=""
-            chart_version=""
-          else
-          echo "::error::Couldn't extract ticket from branch $GITHUB_REF_NAME. If not main the branch name should begin alpha-digit or alpha-digit-digit blocks (e.g. SPSH-1234-test-name or release-1-1-optional-text)"
-            exit 1
-          fi
-          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
-
   build_image_on_push:
     needs: 
-      - determine_image_tag_and_chart_version
+      - create_branch_identifier
     name: 'Publish image and scan with trivy'
     if: ${{ github.event_name == 'push' }}
     permissions:
@@ -86,7 +58,7 @@ jobs:
       image_name: 'schulportal-client'
       run_trivy_scan: true
       image_tag_generation: ${{ github.ref_name == 'main' && 'commit_hash' || 'specified' }}
-      image_tag: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.image_tag }}
+      image_tag: ${{ github.ref_name == 'main' && '' || needs.create_branch_identifier.outputs.image_tag_from_branch }}
       add_latest_tag: ${{ github.ref_name == 'main' }}
       container_registry: 'ghcr.io'
       fail_on_vulnerabilites: true
@@ -118,15 +90,15 @@ jobs:
   release_helm:
     uses: dBildungsplattform/dbp-github-workflows/.github/workflows/chart-release.yaml@7
     needs:
-      - determine_image_tag_and_chart_version
+      - create_branch_identifier
       - select_helm_version_generation_and_image_tag_generation
     secrets: inherit
     with:
       chart_name: schulportal-client
       image_tag_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_IMAGE_TAG_GENERATION }}
-      image_tag: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.image_tag }}
+      image_tag: ${{ github.ref_name == 'main' && '' || needs.create_branch_identifier.outputs.image_tag_from_branch }}
       helm_chart_version_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_HELM_VERSION_GENERATION }}
-      helm_chart_version: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.chart_version }}
+      helm_chart_version: ${{ github.ref_name == 'main' && '' || needs.create_branch_identifier.outputs.chart_version_from_branch }}
 
   wait_for_helm_chart_to_get_published:
     needs:
@@ -144,7 +116,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs:
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -169,7 +141,7 @@ jobs:
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -44,18 +44,49 @@ jobs:
       contents: read
     secrets: inherit
 
+  determine_image_tag_and_chart_version:
+    name: "Determine image tag and chart version from branch name"
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
+      chart_version: ${{ steps.create_image_tag.outputs.chart_version }}
+    steps:
+      - id: create_image_tag
+        run: |
+          timestamp=`echo $(date +'%Y%m%d-%H%M')`
+          regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
+          regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
+          if [[ $GITHUB_REF_NAME =~ $regex_long ]]; then
+            tag="${BASH_REMATCH[1]}"
+            chart_version="0.0.0-$(echo ${tag} | tr [A-Z] [a-z])-${timestamp}"
+          elif [[ $GITHUB_REF_NAME =~ $regex_short ]]; then
+            tag="${BASH_REMATCH[1]}"
+            chart_version="0.0.0-$(echo ${tag} | tr [A-Z] [a-z])-${timestamp}"
+          elif [[ "${{ github.ref_name }}" != 'main' ]]; then
+            tag=""
+            chart_version=""
+          else
+          echo "::error::Couldn't extract ticket from branch $GITHUB_REF_NAME. If not main the branch name should begin alpha-digit or alpha-digit-digit blocks (e.g. SPSH-1234-test-name or release-1-1-optional-text)"
+            exit 1
+          fi
+          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+
   build_image_on_push:
+    needs: 
+      - determine_image_tag_and_chart_version
     name: 'Publish image and scan with trivy'
     if: ${{ github.event_name == 'push' }}
     permissions:
       packages: write
       security-events: write
       contents: read
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/image-publish-trivy.yaml@7
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/image-publish-trivy.yaml@DBP-1179-spsh-image-tag-generation # todo: change to new version
     with:
       image_name: 'schulportal-client'
       run_trivy_scan: true
-      image_tag_generation: ${{ github.ref_name == 'main' && 'commit_hash' || 'ticket_from_branch' }}
+      image_tag_generation: ${{ github.ref_name == 'main' && 'commit_hash' || 'specified' }}
+      image_tag: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.image_tag }}
       add_latest_tag: ${{ github.ref_name == 'main' }}
       container_registry: 'ghcr.io'
       fail_on_vulnerabilites: true
@@ -70,29 +101,32 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     runs-on: ubuntu-latest
     outputs:
-      SELECT_HELM_VERION_GENERATION: ${{ steps.select_generation.outputs.SELECT_HELM_VERION_GENERATION }}
+      SELECT_HELM_VERSION_GENERATION: ${{ steps.select_generation.outputs.SELECT_HELM_VERSION_GENERATION }}
       SELECT_IMAGE_TAG_GENERATION: ${{ steps.select_generation.outputs.SELECT_IMAGE_TAG_GENERATION }}
     steps:
       - id: select_generation
         shell: bash
         run: |
           if ${{ github.ref_name == 'main' }}; then
-            echo "SELECT_HELM_VERION_GENERATION=timestamp" >> "$GITHUB_OUTPUT"
+            echo "SELECT_HELM_VERSION_GENERATION=timestamp" >> "$GITHUB_OUTPUT"
             echo "SELECT_IMAGE_TAG_GENERATION=commit_hash" >> "$GITHUB_OUTPUT"
           else
-            echo "SELECT_HELM_VERION_GENERATION=ticket_from_branch_timestamp" >> "$GITHUB_OUTPUT"
-            echo "SELECT_IMAGE_TAG_GENERATION=ticket_from_branch" >> "$GITHUB_OUTPUT"
+            echo "SELECT_HELM_VERSION_GENERATION=specified" >> "$GITHUB_OUTPUT"
+            echo "SELECT_IMAGE_TAG_GENERATION=specified" >> "$GITHUB_OUTPUT"
           fi
 
   release_helm:
     uses: dBildungsplattform/dbp-github-workflows/.github/workflows/chart-release.yaml@7
     needs:
+      - determine_image_tag_and_chart_version
       - select_helm_version_generation_and_image_tag_generation
     secrets: inherit
     with:
       chart_name: schulportal-client
-      image_tag_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_IMAGE_TAG_GENERATION  }}
-      helm_chart_version_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_HELM_VERION_GENERATION  }}
+      image_tag_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_IMAGE_TAG_GENERATION }}
+      image_tag: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.image_tag }}
+      helm_chart_version_generation: ${{ needs.select_helm_version_generation_and_image_tag_generation.outputs.SELECT_HELM_VERSION_GENERATION }}
+      helm_chart_version: ${{ github.ref_name == 'main' && '' || needs.determine_image_tag_and_chart_version.outputs.chart_version }}
 
   wait_for_helm_chart_to_get_published:
     needs:

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -110,7 +110,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs:
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy-branch-to-namespace.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -121,19 +121,21 @@ jobs:
       - create_branch_identifier
       - wait_for_helm_chart_to_get_published
       - build_image_on_push
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@5
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       dbildungs_iam_server_branch: ${{ needs.branch_meta.outputs.ticket }}
       schulportal_client_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
+      # database_deletion: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      database_deletion: "true" # to force database deletion this has be set to true
     secrets: inherit
 
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy-branch-to-namespace.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -110,7 +110,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs:
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -121,21 +121,21 @@ jobs:
       - create_branch_identifier
       - wait_for_helm_chart_to_get_published
       - build_image_on_push
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@6
     with:
       dbildungs_iam_server_branch: ${{ needs.branch_meta.outputs.ticket }}
       schulportal_client_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
-      # database_deletion: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
-      database_deletion: "true" # to force database deletion this has be set to true
+      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      # database_recreation: "true" # to force database recreation this has be set to true
     secrets: inherit
 
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ github.event.ref }}
 


### PR DESCRIPTION
# Description

- Switch to Version 6 of convert-branch-name and get-branch-meta (DBP-1179 -> https://github.com/dBildungsplattform/spsh-app-deploy/commit/5ff578fa4ed704a0069448c03fd9ca64153b02f1)
- **New Feature - New Naming Conventions:** 
  - branches with alpha-digit-digit blocks can now be deployed with corresponding image-tag, chart-version and k8s namespace, this allows _release-X-X_ branches
  - the generated kubernetes namespace identifier does not incorporate the complete branch name anymore. Multiple Namespaces with the same ticket number were not functioning anyway, since the ingress could not share a name. Restricting the Namesape enabled us to improve the pipeline complexity. 
- **New Feature - Optional Database Recreation:** 
  - it is now possible to set a boolean (actually it is a string) for database recreation in the deploy job of the dev pipeline to enable/disable database recreation
  - Per default databases are now only recreated if branch is main
  - If one wants to recreate databases on deployment, one can set the database_recreation to "true" or manually delete them

Successfully tested here: https://github.com/dBildungsplattform/schulportal-client/actions/runs/12376395563

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.