### PR TITLE
Less col space

### DIFF
--- a/src/views/admin/PersonDetailsView.vue
+++ b/src/views/admin/PersonDetailsView.vue
@@ -1975,6 +1975,7 @@
               </v-col>
               <v-col
                 cols="12"
+                md="7"
                 v-for="zuordnung in zuordnungenWithPendingChanges?.filter((zuordnung: Zuordnung) => zuordnung.editable)"
                 :key="zuordnung.sskId"
                 :data-testid="`person-zuordnung-${zuordnung.sskId}`"


### PR DESCRIPTION
# Description

When editing, the Zuordnungen should only take a specific amount of cols (7) instead of the whole 12.

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.