### PR TITLE
moved logic to unmount

### DIFF
--- a/src/views/admin/PersonCreationView.vue
+++ b/src/views/admin/PersonCreationView.vue
@@ -352,8 +352,6 @@
       personenkontextStore.errorCode === 'REQUIRED_STEP_UP_LEVEL_NOT_MET'
     ) {
       formContext.resetForm();
-    } else {
-      personenkontextStore.createdPersonWithKontext = null;
     }
     await router.push({ name: 'person-management' });
   }
@@ -656,9 +654,6 @@
       showUnsavedChangesDialog.value = true;
       blockedNext = next;
     } else {
-      personenkontextStore.requestedWithSystemrecht = undefined;
-      personenkontextStore.createdPersonWithKontext = null;
-      personenkontextStore.landesbediensteteCommitResponse = null;
       next();
     }
   });
@@ -702,6 +697,8 @@
 
   onUnmounted(() => {
     personenkontextStore.requestedWithSystemrecht = undefined;
+    personenkontextStore.createdPersonWithKontext = null;
+    personenkontextStore.landesbediensteteCommitResponse = null;
     window.removeEventListener('beforeunload', preventNavigation);
   });
 </script>


### PR DESCRIPTION
# Description

Logic to reset the created person is moved to unmount instead of onBeforeRouteLeave to avoid showing the form for a split second.

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.