### PR TITLE
SPSH-2519

### DIFF
--- a/src/components/filter/KlassenFilter.vue
+++ b/src/components/filter/KlassenFilter.vue
@@ -118,12 +118,8 @@
     return false;
   });
 
-  const isDisplayName = (name: string): boolean => {
-    return translatedKlassen.value.find((klasse: TranslatedObject) => klasse.title === name) !== undefined;
-  };
-
   const updateSearchString = (searchString: string | undefined): void => {
-    if (searchString && !isDisplayName(searchString)) {
+    if (searchString ) {
       klassenFilter.searchString = searchString;
     } else {
       delete klassenFilter.searchString;

--- a/src/components/filter/KlassenFilter.vue
+++ b/src/components/filter/KlassenFilter.vue
@@ -119,7 +119,7 @@
   });
 
   const updateSearchString = (searchString: string | undefined): void => {
-    if (searchString ) {
+    if (searchString) {
       klassenFilter.searchString = searchString;
     } else {
       delete klassenFilter.searchString;

--- a/src/stores/OrganisationStore.spec.ts
+++ b/src/stores/OrganisationStore.spec.ts
@@ -1281,7 +1281,7 @@ describe('OrganisationStore', () => {
         const mockResponse: Organisation[] = [DoFactory.getSchule()];
 
         mockadapter.onGet('/api/organisationen?offset=0&limit=30&typ=KLASSE').replyOnce(200, mockResponse, {
-          'x-paging-total': '1',
+          'x-paging-pagetotal': '1',
         });
         const promise: Promise<void> = organisationStore.loadKlassenForFilter(
           {

--- a/src/stores/OrganisationStore.ts
+++ b/src/stores/OrganisationStore.ts
@@ -715,7 +715,7 @@ export const useOrganisationStore: StoreDefinition<
           filter?.organisationIds,
         );
         klassenFilter.filterResult = response.data;
-        klassenFilter.total = +response.headers['x-paging-total'];
+        klassenFilter.total = +response.headers['x-paging-pagetotal'];
       } catch (error: unknown) {
         klassenFilter.errorCode = getResponseErrorCode(error, 'UNSPECIFIED_ERROR');
       } finally {


### PR DESCRIPTION
# Description

- Klassenfilter wasn't triggering a backend request on search if the search string was among it's items. This is wrong because the pageTotal wasn't updating.
- Using PageTotal instead of Total since Total also counts the selected items while searching.

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.