### PR TITLE
SPSH-2415: reset rolle search

### DIFF
--- a/src/views/admin/PersonManagementView.vue
+++ b/src/views/admin/PersonManagementView.vue
@@ -372,6 +372,12 @@
     }, 500);
   }
 
+  const handleFocusChange = (focused: boolean): void => {
+    if (!focused) {
+      searchInputRollen.value = '';
+    }
+  };
+
   // Define a mapping between complex table keys and expected backend keys
   const keyMapping: Record<string, SortField> = {
     'person.name.familienname': SortField.Familienname,
@@ -720,6 +726,7 @@
             required="true"
             @update:modelValue="setRolleFilter"
             @update:search="updateRollenSearch"
+            @update:focused="handleFocusChange"
             variant="outlined"
             v-model="selectedRollen"
             v-model:search="searchInputRollen"

--- a/src/views/admin/PersonManagementView.vue
+++ b/src/views/admin/PersonManagementView.vue
@@ -372,12 +372,6 @@
     }, 500);
   }
 
-  const handleFocusChange = (focused: boolean): void => {
-    if (!focused) {
-      searchInputRollen.value = '';
-    }
-  };
-
   // Define a mapping between complex table keys and expected backend keys
   const keyMapping: Record<string, SortField> = {
     'person.name.familienname': SortField.Familienname,
@@ -726,7 +720,6 @@
             required="true"
             @update:modelValue="setRolleFilter"
             @update:search="updateRollenSearch"
-            @update:focused="handleFocusChange"
             variant="outlined"
             v-model="selectedRollen"
             v-model:search="searchInputRollen"

--- a/src/views/admin/PersonManagementView.vue
+++ b/src/views/admin/PersonManagementView.vue
@@ -372,9 +372,10 @@
     }, 500);
   }
 
-  const handleFocusChange = (focused: boolean): void => {
-    if (!focused) {
+  const handleFocusChange = async (focused: boolean): Promise<void> => {
+    if (!focused && searchInputRollen.value) {
       searchInputRollen.value = '';
+      await updateRollenSearch(searchInputRollen.value);
     }
   };
 


### PR DESCRIPTION
# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

Autocomplete has different behaviors for search and clear, depending on `multiple`. When `multiple: true` setting `search = ''` does not seem to trigger `@update:search`, which caused the issue. The autocomplete for orgas does not use this and works.
I added a manual call to `updateRollenSearch` to fix the issue.

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->
https://ticketsystem.dbildungscloud.de/browse/SPSH-2415

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.