### PR TITLE
SPSH-3455

### DIFF
--- a/src/components/admin/ResultTable.vue
+++ b/src/components/admin/ResultTable.vue
@@ -178,6 +178,18 @@
     @update:items-per-page="(limit: number) => $emit('onItemsPerPageUpdate', limit)"
     @update:model-value="emitSelectedRows"
   >
+    <template v-slot:loading>
+      <div class="d-flex flex-column align-center justify-center pa-4">
+        <v-progress-circular
+          color="primary"
+          indeterminate
+        />
+        <div class="mt-2">
+          {{ $t('loadingData') }}
+        </div>
+      </div>
+    </template>
+
     <template
       v-for="(_, name) in $slots"
       v-slot:[name]="slotProps"
@@ -191,4 +203,9 @@
   </v-data-table-server>
 </template>
 
+<style scoped>
+  .result-table :deep(.v-data-table-progress) {
+    display: none !important;
+  }
+</style>
 <style></style>

--- a/src/components/admin/ResultTable.vue
+++ b/src/components/admin/ResultTable.vue
@@ -91,12 +91,6 @@
     }
   }
 
-  interface Slots {
-    default: (props: { default: string }) => string;
-    top: (props: { top: number }) => string;
-    bottom: (props: { bottom: boolean }) => string;
-  }
-
   type SortItem = {
     key: string;
     order?: boolean | 'asc' | 'desc';
@@ -170,6 +164,8 @@
     :items-per-page-options="[5, 30, 50, 100, 300]"
     :items-per-page-text="'itemsPerPage'"
     :item-value="itemValuePath"
+    :loading="loading"
+    :loading-text="$t('loadingData')"
     :page="currentPage"
     select-strategy="page"
     :show-current-page="true"
@@ -183,8 +179,9 @@
     @update:model-value="emitSelectedRows"
   >
     <template
-      v-for="(_, name) in $slots as unknown as Readonly<Slots>"
-      #[name]="slotProps"
+      v-for="(_, name) in $slots"
+      v-slot:[name]="slotProps"
+      :key="name"
     >
       <slot
         :name="name"

--- a/src/components/admin/klassen/KlasseDelete.spec.ts
+++ b/src/components/admin/klassen/KlasseDelete.spec.ts
@@ -12,7 +12,6 @@ interface DefaultProps {
   klassenname: string;
   schulname: string;
   isLoading: boolean;
-  useIconActivator: boolean;
 }
 
 const defaultProps: DefaultProps = {
@@ -22,7 +21,6 @@ const defaultProps: DefaultProps = {
   klassenname: '1A',
   schulname: 'schule',
   isLoading: false,
-  useIconActivator: false,
 };
 
 function mountDialog(props: Partial<DefaultProps> = {}): Wrapper {

--- a/src/components/admin/klassen/KlasseDelete.spec.ts
+++ b/src/components/admin/klassen/KlasseDelete.spec.ts
@@ -1,89 +1,93 @@
-import { VueWrapper, mount } from '@vue/test-utils';
-import { expect, test } from 'vitest';
-import { nextTick, type Component } from 'vue';
+import { DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 import KlasseDelete from './KlasseDelete.vue';
 
-let wrapper: VueWrapper | null = null;
+type Wrapper = VueWrapper<InstanceType<typeof KlasseDelete>>;
 
-beforeEach(() => {
-  document.body.innerHTML = `
-    <div>
-      <div id="app"></div>
-    </div>
-  `;
+interface DefaultProps {
+  modelValue: boolean;
+  errorCode: string;
+  klassenId: string;
+  klassenname: string;
+  schulname: string;
+  isLoading: boolean;
+  useIconActivator: boolean;
+}
 
-  wrapper = mount(KlasseDelete, {
-    attachTo: document.getElementById('app') || '',
-    props: {
-      modelValue: false,
-      errorCode: '',
-      isLoading: false,
-      klassenId: '1',
-      klassenname: '1A',
-      schulname: 'schule',
-      useIconActivator: false,
-    },
+const defaultProps: DefaultProps = {
+  modelValue: true,
+  errorCode: '',
+  klassenId: '1',
+  klassenname: '1A',
+  schulname: 'schule',
+  isLoading: false,
+  useIconActivator: false,
+};
+
+function mountDialog(props: Partial<DefaultProps> = {}): Wrapper {
+  return mount(KlasseDelete, {
+    props: { ...defaultProps, ...props },
     global: {
-      components: {
-        KlasseDelete: KlasseDelete as Component,
+      stubs: {
+        transition: false,
+        'v-dialog': {
+          name: 'v-dialog',
+          template: `
+            <div>
+              <slot name="activator" :props="{}" />
+              <slot name="default" :isActive="{ value: true }" />
+            </div>
+          `,
+        },
       },
     },
   });
-});
+}
 
-describe('KlasseDelete', () => {
-  test('it opens and closes the dialog via buttons', async () => {
-    wrapper?.setProps({ useIconActivator: false });
-    wrapper?.find('[data-testid="open-klasse-delete-dialog-button"]').trigger('click');
-    await nextTick();
+describe('KlasseDelete.vue', () => {
+  it('renders confirmation state by default', () => {
+    const wrapper: Wrapper = mountDialog();
 
-    expect(document.querySelector('[data-testid="klasse-delete-confirmation-text"]')).not.toBeNull();
-
-    const cancelDeleteButton: HTMLElement | undefined = document.querySelectorAll<HTMLElement>(
-      '[data-testid="cancel-klasse-delete-button"]',
-    )[0];
-    cancelDeleteButton?.click();
-    await nextTick();
-
-    expect(document.querySelector('[data-testid="close-klasse-delete-dialog-button"]')).toBeNull();
+    expect(wrapper.html()).toContain('klasse-delete-confirmation-text');
+    expect(wrapper.html()).toContain('1A');
   });
 
-  test('it opens the dialog via icon activator and closes via layout card', async () => {
-    wrapper?.setProps({ useIconActivator: true });
-    await nextTick();
+  it('emits onDeleteKlasse when delete button is clicked', async () => {
+    const wrapper: Wrapper = mountDialog();
 
-    wrapper?.find('[data-testid="open-klasse-delete-dialog-icon"]').trigger('click');
-    await nextTick();
+    const btn: DOMWrapper<Element> = wrapper.find('[data-testid="klasse-delete-button"]');
 
-    expect(document.querySelector('[data-testid="klasse-delete-confirmation-text"]')).not.toBeNull();
+    expect(btn.exists()).toBe(true);
 
-    const closeDialogButton: HTMLElement = document.querySelector(
-      '[data-testid="close-layout-card-button"]',
-    ) as HTMLElement;
-    closeDialogButton.click();
+    await btn.trigger('click');
+
+    expect(wrapper.emitted('onDeleteKlasse')).toBeTruthy();
+    expect(wrapper.emitted('onDeleteKlasse')?.[0]).toEqual(['1']);
   });
 
-  test('it deletes a klasse and navigates back to management', async () => {
-    wrapper?.setProps({ useIconActivator: false });
+  it('shows success state after delete and emits onClose', async () => {
+    const wrapper: Wrapper = mountDialog();
 
-    wrapper?.find('[data-testid="open-klasse-delete-dialog-button"]').trigger('click');
+    // trigger delete
+    await wrapper.find('[data-testid="klasse-delete-button"]').trigger('click');
     await nextTick();
 
-    expect(document.querySelector('[data-testid="klasse-delete-confirmation-text"]')).not.toBeNull();
+    const closeBtn: DOMWrapper<Element> = wrapper.find('[data-testid="close-klasse-delete-success-dialog-button"]');
 
-    const klasseDeleteButton: HTMLElement | undefined = document.querySelectorAll<HTMLElement>(
-      '[data-testid="klasse-delete-button"]',
-    )[0];
-    klasseDeleteButton?.click();
-    await wrapper?.setProps({ isLoading: false });
-    await nextTick();
+    expect(closeBtn.exists()).toBe(true);
 
-    expect(document.querySelector('[data-testid="klasse-delete-success-text"]')).not.toBeNull();
+    await closeBtn.trigger('click');
 
-    const closeDialogButton: HTMLElement | undefined = document.querySelectorAll<HTMLElement>(
-      '[data-testid="close-klasse-delete-success-dialog-button"]',
-    )[0];
-    closeDialogButton?.click();
-    await nextTick();
+    expect(wrapper.emitted('onClose')).toBeTruthy();
+  });
+
+  it('disables delete button when loading', () => {
+    const wrapper: Wrapper = mountDialog({ isLoading: true });
+
+    const btn: DOMWrapper<Element> = wrapper.find('[data-testid="klasse-delete-button"]');
+
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes('disabled')).toBeDefined();
   });
 });

--- a/src/components/admin/klassen/KlasseDelete.spec.ts
+++ b/src/components/admin/klassen/KlasseDelete.spec.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
   wrapper = mount(KlasseDelete, {
     attachTo: document.getElementById('app') || '',
     props: {
+      modelValue: false,
       errorCode: '',
       isLoading: false,
       klassenId: '1',

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import LayoutCard from '@/components/cards/LayoutCard.vue';
-  import { computed, ref, type ComputedRef, type Ref } from 'vue';
+  import { computed, ref, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
   import { useI18n, type Composer } from 'vue-i18n';
   import { useDisplay } from 'vuetify';
 
@@ -15,9 +15,11 @@
     schulname: string;
     isLoading: boolean;
     useIconActivator: boolean;
+    modelValue: boolean;
   };
 
   type Emits = {
+    (event: 'update:modelValue', value: boolean): void;
     (event: 'onDeleteKlasse', klasseId: string): void;
     (event: 'onClose'): void;
   };
@@ -34,6 +36,11 @@
 
   const hasTriggeredAction: Ref<boolean> = ref(false);
   const isClosing: Ref<boolean> = ref(false);
+
+  const model: WritableComputedRef<boolean, boolean> = computed({
+    get: () => props.modelValue,
+    set: (val: boolean) => emit('update:modelValue', val),
+  });
 
   const state: ComputedRef<State> = computed(() => {
     // NOTE: order of checks and the two different paths into SUCCESS are important here
@@ -57,9 +64,9 @@
     emit('onDeleteKlasse', klasseId);
   }
 
-  function closeSuccessDialog(isActive: Ref<boolean>): void {
+  function closeSuccessDialog(): void {
     isClosing.value = true;
-    closeKlasseDeleteDialog(isActive);
+    model.value = false;
     emit('onClose');
   }
 
@@ -85,6 +92,7 @@
 
 <template>
   <v-dialog
+    v-model="model"
     persistent
     @after-leave="resetState"
   >
@@ -165,7 +173,7 @@
                 :block="mdAndDown"
                 class="primary"
                 data-testid="close-klasse-delete-success-dialog-button"
-                @click.stop="closeSuccessDialog(isActive)"
+                @click.stop="closeSuccessDialog()"
               >
                 {{ $t('close') }}
               </v-btn>

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import LayoutCard from '@/components/cards/LayoutCard.vue';
-  import { computed, ref, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
+  import { computed, ref, type ComputedRef, type ModelRef, type Ref } from 'vue';
   import { useI18n, type Composer } from 'vue-i18n';
   import { useDisplay } from 'vuetify';
 
@@ -36,10 +36,7 @@
   const hasTriggeredAction: Ref<boolean> = ref(false);
   const isClosing: Ref<boolean> = ref(false);
 
-  const model: WritableComputedRef<boolean, boolean> = computed({
-    get: () => props.modelValue,
-    set: (val: boolean) => emit('update:modelValue', val),
-  });
+  const model: ModelRef<boolean | undefined> = defineModel<boolean>();
 
   const state: ComputedRef<State> = computed(() => {
     if (isClosing.value) {

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -14,7 +14,6 @@
     klassenId: string;
     schulname: string;
     isLoading: boolean;
-    useIconActivator: boolean;
     modelValue: boolean;
   };
 

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -91,6 +91,7 @@
 
 <template>
   <v-dialog
+    persistent
     v-model="model"
     @after-leave="resetState"
   >

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -93,29 +93,8 @@
 <template>
   <v-dialog
     v-model="model"
-    persistent
     @after-leave="resetState"
   >
-    <template #activator="{ props }">
-      <v-btn
-        v-if="!useIconActivator"
-        class="secondary button"
-        data-testid="open-klasse-delete-dialog-button"
-        v-bind="props"
-        :block="mdAndDown"
-      >
-        {{ $t('admin.klasse.deleteKlasse') }}
-      </v-btn>
-      <v-icon
-        v-else
-        :title="$t('admin.klasse.deleteKlasse')"
-        data-testid="open-klasse-delete-dialog-icon"
-        icon="mdi-delete"
-        size="small"
-        v-bind="props"
-      />
-    </template>
-
     <template #default="{ isActive }">
       <LayoutCard
         :headline-test-id="state === State.SUCCESS ? 'klasse-delete-success' : 'klasse-delete-confirmation'"

--- a/src/components/admin/klassen/KlasseDelete.vue
+++ b/src/components/admin/klassen/KlasseDelete.vue
@@ -42,16 +42,14 @@
   });
 
   const state: ComputedRef<State> = computed(() => {
-    // NOTE: order of checks and the two different paths into SUCCESS are important here
-    // this freezes the content of the dialog in the success state, while the close-animation is running
-    // otherwise it will briefly show the initial template, because the isLoading-prop is true
     if (isClosing.value) {
       return State.SUCCESS;
     }
     if (props.isLoading) {
       return State.LOADING;
     }
-    return hasTriggeredAction.value ? State.SUCCESS : State.CONFIRM;
+    // Only show success if action was triggered AND there's no error
+    return hasTriggeredAction.value && !props.errorCode ? State.SUCCESS : State.CONFIRM;
   });
 
   function closeKlasseDeleteDialog(isActive: Ref<boolean>): void {
@@ -110,7 +108,7 @@
                 cols="10"
               >
                 <span
-                  v-if="state === State.SUCCESS && !props.errorCode"
+                  v-if="state === State.SUCCESS"
                   data-testid="klasse-delete-success-text"
                 >
                   {{ deleteKlasseSuccessMessage }}

--- a/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
+++ b/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
@@ -87,10 +87,4 @@ describe('ServiceProviderDelete.vue', () => {
     expect(btn.exists()).toBe(true);
     expect(btn.attributes('disabled')).toBeDefined();
   });
-
-  it('renders error state when errorCode is set', () => {
-    const wrapper: Wrapper = mountDialog({ errorCode: 'someError' });
-
-    expect(wrapper.html()).toContain('someError');
-  });
 });

--- a/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
+++ b/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
@@ -5,6 +5,7 @@ import ServiceProviderDelete from './ServiceProviderDelete.vue';
 
 describe('ServiceProviderDelete.vue', () => {
   interface DefaultProps {
+    modelValue: boolean;
     errorCode: string;
     serviceProviderId: string;
     serviceProviderName: string;
@@ -12,6 +13,7 @@ describe('ServiceProviderDelete.vue', () => {
   }
 
   const defaultProps: DefaultProps = {
+    modelValue: false,
     errorCode: '',
     serviceProviderId: 'sp-123',
     serviceProviderName: 'Test Provider',

--- a/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
+++ b/src/components/admin/service-provider/ServiceProviderDelete.spec.ts
@@ -3,93 +3,94 @@ import { describe, expect, it } from 'vitest';
 import { nextTick } from 'vue';
 import ServiceProviderDelete from './ServiceProviderDelete.vue';
 
-describe('ServiceProviderDelete.vue', () => {
-  interface DefaultProps {
-    modelValue: boolean;
-    errorCode: string;
-    serviceProviderId: string;
-    serviceProviderName: string;
-    isLoading: boolean;
-  }
+type Wrapper = VueWrapper<InstanceType<typeof ServiceProviderDelete>>;
 
-  const defaultProps: DefaultProps = {
-    modelValue: false,
-    errorCode: '',
-    serviceProviderId: 'sp-123',
-    serviceProviderName: 'Test Provider',
-    isLoading: false,
-  };
+interface DefaultProps {
+  modelValue: boolean;
+  errorCode: string;
+  serviceProviderId: string;
+  serviceProviderName: string;
+  isLoading: boolean;
+}
 
-  async function openDialog(wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>>): Promise<void> {
-    const activator: DOMWrapper<HTMLElement> = wrapper.find('[data-testid="open-service-provider-delete-dialog-icon"]');
-    expect(activator.exists()).toBe(true);
-    await activator.trigger('click');
-    await nextTick();
-    await nextTick(); // ensure dialog is rendered
-  }
+const defaultProps: DefaultProps = {
+  modelValue: true,
+  errorCode: '',
+  serviceProviderId: 'sp-123',
+  serviceProviderName: 'Test Provider',
+  isLoading: false,
+};
 
-  function mountDialog(props: Partial<DefaultProps> = {}): VueWrapper<InstanceType<typeof ServiceProviderDelete>> {
-    return mount(ServiceProviderDelete, {
-      props: { ...defaultProps, ...props },
-      global: {
-        stubs: {
-          transition: false,
-          'v-dialog': {
-            name: 'v-dialog',
-            template:
-              '<div><slot name="activator" :props="{}" /><slot name="default" :isActive="{ value: true }" /></div>',
-          },
+function mountDialog(props: Partial<DefaultProps> = {}): Wrapper {
+  return mount(ServiceProviderDelete, {
+    props: { ...defaultProps, ...props },
+    global: {
+      stubs: {
+        transition: false,
+        'v-dialog': {
+          name: 'v-dialog',
+          template: `
+            <div>
+              <slot name="activator" :props="{}" />
+              <slot name="default" :isActive="{ value: true }" />
+            </div>
+          `,
         },
       },
-    });
-  }
+    },
+  });
+}
 
-  it('renders confirmation message by default', async (): Promise<void> => {
-    const wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>> = mountDialog();
-    await openDialog(wrapper);
-    const confirmationText: DOMWrapper<HTMLElement> = wrapper.find(
-      '[data-testid="service-provider-delete-confirmation-text"]',
-    );
-    expect(confirmationText.exists()).toBe(true);
-    expect(wrapper.html()).toContain('Möchten Sie das Angebot Test Provider wirklich löschen');
+describe('ServiceProviderDelete.vue', () => {
+  it('renders confirmation state by default', () => {
+    const wrapper: Wrapper = mountDialog();
+
+    expect(wrapper.find('[data-testid="service-provider-delete-confirmation-text"]').exists()).toBe(true);
+    expect(wrapper.html()).toContain('Test Provider');
   });
 
-  it('renders error message if errorCode is set', async (): Promise<void> => {
-    const wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>> = mountDialog({ errorCode: 'someError' });
-    await openDialog(wrapper);
-    expect(wrapper.html()).toContain('admin.angebot.errors.someError');
-  });
+  it('emits onDeleteServiceProvider when delete button is clicked', async () => {
+    const wrapper: Wrapper = mountDialog();
 
-  it('emits onDeleteServiceProvider when delete button is clicked', async (): Promise<void> => {
-    const wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>> = mountDialog();
-    await openDialog(wrapper);
-    const btn: DOMWrapper<HTMLElement> = wrapper.find('[data-testid="service-provider-delete-button"]');
+    const btn: DOMWrapper<Element> = wrapper.find('[data-testid="service-provider-delete-button"]');
+
     expect(btn.exists()).toBe(true);
+
     await btn.trigger('click');
+
     expect(wrapper.emitted('onDeleteServiceProvider')).toBeTruthy();
-    expect(wrapper.emitted('onDeleteServiceProvider')![0]).toEqual(['sp-123']);
+    expect(wrapper.emitted('onDeleteServiceProvider')?.[0]).toEqual(['sp-123']);
   });
 
-  it('emits onClose when close button is clicked in complete state', async (): Promise<void> => {
-    const wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>> = mountDialog();
-    await openDialog(wrapper);
-    // Simulate state COMPLETE
-    await wrapper.find('[data-testid="service-provider-delete-button"]')?.trigger('click');
+  it('shows success state after delete and emits onClose', async () => {
+    const wrapper: Wrapper = mountDialog();
+
+    await wrapper.find('[data-testid="service-provider-delete-button"]').trigger('click');
     await nextTick();
-    const btn: DOMWrapper<HTMLElement> = wrapper.find(
-      '[data-testid="close-service-provider-delete-complete-dialog-button"]',
+
+    const closeBtn: DOMWrapper<Element> = wrapper.find(
+      '[data-testid="close-service-provider-delete-success-dialog-button"]',
     );
-    if (btn.exists()) {
-      await btn.trigger('click');
-      expect(wrapper.emitted('onClose')).toBeTruthy();
-    }
+
+    expect(closeBtn.exists()).toBe(true);
+
+    await closeBtn.trigger('click');
+
+    expect(wrapper.emitted('onClose')).toBeTruthy();
   });
 
-  it('disables delete button when loading', async (): Promise<void> => {
-    const wrapper: VueWrapper<InstanceType<typeof ServiceProviderDelete>> = mountDialog({ isLoading: true });
-    await openDialog(wrapper);
-    const btn: DOMWrapper<HTMLElement> = wrapper.find('[data-testid="service-provider-delete-button"]');
+  it('disables delete button when loading', () => {
+    const wrapper: Wrapper = mountDialog({ isLoading: true });
+
+    const btn: DOMWrapper<Element> = wrapper.find('[data-testid="service-provider-delete-button"]');
+
     expect(btn.exists()).toBe(true);
     expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('renders error state when errorCode is set', () => {
+    const wrapper: Wrapper = mountDialog({ errorCode: 'someError' });
+
+    expect(wrapper.html()).toContain('someError');
   });
 });

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -51,12 +51,11 @@
     if (props.isLoading) {
       return State.LOADING;
     }
-    return hasTriggeredAction.value ? State.COMPLETE : State.CONFIRM;
+    return hasTriggeredAction.value && !props.errorCode ? State.COMPLETE : State.CONFIRM;
   });
 
-  function closeServiceProviderDeleteDialog(isActive: Ref<boolean>, successful: boolean): void {
+  function closeServiceProviderDeleteDialog(isActive: Ref<boolean>): void {
     isActive.value = false;
-    emit('onClose', successful);
   }
 
   function handleServiceProviderDelete(serviceProviderId: string): void {
@@ -66,7 +65,7 @@
 
   function closeSuccessDialog(isActive: Ref<boolean>): void {
     isClosing.value = true;
-    closeServiceProviderDeleteDialog(isActive, props.errorCode === '');
+    closeServiceProviderDeleteDialog(isActive);
   }
 
   const deleteServiceProviderConfirmationMessage: ComputedRef<string> = computed(() => {
@@ -100,7 +99,7 @@
         "
         :closable="state === State.COMPLETE ? false : true"
         :header="$t('admin.angebot.delete.title')"
-        @on-close-clicked="closeServiceProviderDeleteDialog(isActive, false)"
+        @on-close-clicked="closeServiceProviderDeleteDialog(isActive)"
       >
         <v-card-text>
           <v-container>
@@ -137,7 +136,7 @@
                 :block="mdAndDown"
                 class="secondary button"
                 data-testid="cancel-service-provider-delete-dialog-button"
-                @click.stop="closeServiceProviderDeleteDialog(isActive, false)"
+                @click.stop="closeServiceProviderDeleteDialog(isActive)"
               >
                 {{ $t('cancel') }}
               </v-btn>
@@ -147,16 +146,11 @@
               sm="6"
               md="4"
             >
-              <template> </template>
               <v-btn
                 v-if="state === State.COMPLETE"
                 :block="mdAndDown"
                 class="primary"
-                :data-testid="
-                  props.errorCode
-                    ? 'close-service-provider-delete-error-dialog-button'
-                    : 'close-service-provider-delete-success-dialog-button'
-                "
+                :data-testid="'close-service-provider-delete-success-dialog-button'"
                 @click.stop="closeSuccessDialog(isActive)"
               >
                 {{ $t('close') }}

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
+  import { computed, ref, type ComputedRef, type ModelRef, type Ref } from 'vue';
   import { useI18n, type Composer } from 'vue-i18n';
   import { useDisplay } from 'vuetify';
 
@@ -33,10 +33,7 @@
 
   const emit: Emits = defineEmits<Emits>();
 
-  const model: WritableComputedRef<boolean, boolean> = computed({
-    get: () => props.modelValue,
-    set: (val: boolean) => emit('update:modelValue', val),
-  });
+  const model: ModelRef<boolean | undefined> = defineModel<boolean>();
 
   const hasTriggeredAction: Ref<boolean> = ref(false);
   const isClosing: Ref<boolean> = ref(false);

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref, type ComputedRef, type Ref } from 'vue';
+  import { computed, ref, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
   import { useI18n, type Composer } from 'vue-i18n';
   import { useDisplay } from 'vuetify';
 
@@ -10,6 +10,7 @@
   const { mdAndDown }: { mdAndDown: Ref<boolean> } = useDisplay();
 
   type Props = {
+    modelValue: boolean;
     errorCode: string;
     serviceProviderId: string;
     serviceProviderName: string;
@@ -17,6 +18,7 @@
   };
 
   type Emits = {
+    (event: 'update:modelValue', value: boolean): void;
     (event: 'onDeleteServiceProvider', serviceProviderId: string): void;
     (event: 'onClose', completed: boolean): void;
   };
@@ -30,6 +32,11 @@
   const props: Props = defineProps<Props>();
 
   const emit: Emits = defineEmits<Emits>();
+
+  const model: WritableComputedRef<boolean, boolean> = computed({
+    get: () => props.modelValue,
+    set: (val: boolean) => emit('update:modelValue', val),
+  });
 
   const hasTriggeredAction: Ref<boolean> = ref(false);
   const isClosing: Ref<boolean> = ref(false);
@@ -83,6 +90,7 @@
 <template>
   <v-dialog
     persistent
+    v-model="model"
     @after-leave="resetState"
   >
     <template #activator="{ props }">

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -93,16 +93,6 @@
     v-model="model"
     @after-leave="resetState"
   >
-    <template #activator="{ props }">
-      <v-icon
-        :title="$t('admin.angebot.delete.title')"
-        data-testid="open-service-provider-delete-dialog-icon"
-        icon="mdi-delete"
-        size="small"
-        v-bind="props"
-      />
-    </template>
-
     <template #default="{ isActive }">
       <LayoutCard
         :headline-test-id="

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -109,15 +109,8 @@
                 class="text-center"
                 cols="10"
               >
-                <span v-if="props.errorCode">
-                  {{
-                    t(`admin.angebot.errors.${props.errorCode}`, {
-                      serviceProviderName: props.serviceProviderName,
-                    })
-                  }}
-                </span>
                 <span
-                  v-else-if="state === State.COMPLETE && !props.errorCode"
+                  v-if="state === State.COMPLETE && !props.errorCode"
                   data-testid="service-provider-delete-complete-text"
                 >
                   {{ deleteServiceProviderSuccessMessage }}

--- a/src/components/admin/service-provider/ServiceProviderDelete.vue
+++ b/src/components/admin/service-provider/ServiceProviderDelete.vue
@@ -56,6 +56,7 @@
 
   function closeServiceProviderDeleteDialog(isActive: Ref<boolean>): void {
     isActive.value = false;
+    emit('onClose', false);
   }
 
   function handleServiceProviderDelete(serviceProviderId: string): void {
@@ -66,6 +67,7 @@
   function closeSuccessDialog(isActive: Ref<boolean>): void {
     isClosing.value = true;
     closeServiceProviderDeleteDialog(isActive);
+    emit('onClose', true);
   }
 
   const deleteServiceProviderConfirmationMessage: ComputedRef<string> = computed(() => {

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -911,6 +911,7 @@
   "no": "Nein",
   "from": "von",
   "noDataFound": "Keine Daten gefunden.",
+  "loadingData": "Daten werden abgerufen...",
   "pagination": {
     "all": "Alle",
     "pageText": "{interval} von {total} Einträgen"

--- a/src/views/admin/organisationen/KlasseDetailsView.vue
+++ b/src/views/admin/organisationen/KlasseDetailsView.vue
@@ -36,6 +36,7 @@
 
   const currentKlasseId: string = route.params['id'] as string;
   const isEditActive: Ref<boolean> = ref(false);
+  const isDeleteDialogOpen: Ref<boolean, boolean> = ref(false);
 
   const showUnsavedChangesDialog: Ref<boolean> = ref(false);
 
@@ -118,6 +119,7 @@
   }
 
   async function navigateToKlasseManagement(): Promise<void> {
+    isDeleteDialogOpen.value = false;
     await router.push({ name: 'klasse-management' });
   }
 
@@ -270,6 +272,7 @@
                     <div class="d-flex justify-sm-end">
                       <KlasseDelete
                         ref="klasse-delete"
+                        v-model="isDeleteDialogOpen"
                         :error-code="organisationStore.errorCode"
                         :klassenname="organisationStore.currentKlasse?.name || ''"
                         :klassen-id="organisationStore.currentKlasse?.id || ''"

--- a/src/views/admin/organisationen/KlasseDetailsView.vue
+++ b/src/views/admin/organisationen/KlasseDetailsView.vue
@@ -270,6 +270,14 @@
                     sm="6"
                   >
                     <div class="d-flex justify-sm-end">
+                      <v-btn
+                        class="secondary button"
+                        data-testid="open-klasse-delete-dialog-button"
+                        :block="mdAndDown"
+                        @click="isDeleteDialogOpen = true"
+                      >
+                        {{ $t('admin.klasse.deleteKlasse') }}
+                      </v-btn>
                       <KlasseDelete
                         ref="klasse-delete"
                         v-model="isDeleteDialogOpen"

--- a/src/views/admin/organisationen/KlassenManagementView.vue
+++ b/src/views/admin/organisationen/KlassenManagementView.vue
@@ -185,6 +185,8 @@
 
   const handleAlertClose = async (): Promise<void> => {
     organisationStore.errorCode = '';
+    isDeleteDialogOpen.value = false;
+    klasseToDelete.value = null;
     await reloadData(klassenListFilter.value);
   };
 

--- a/src/views/admin/organisationen/KlassenManagementView.vue
+++ b/src/views/admin/organisationen/KlassenManagementView.vue
@@ -29,6 +29,9 @@
 
   const klasseColumnKey: string = 'name';
 
+  const klasseToDelete: Ref<Organisation | null> = ref(null);
+  const isDeleteDialogOpen: Ref<boolean, boolean> = ref(false);
+
   let defaultHeaders: Mutable<Headers> = [
     {
       title: t('admin.klasse.klasse'),
@@ -185,9 +188,10 @@
     await reloadData(klassenListFilter.value);
   };
 
-  const handleKlasseDeleteClose = async (): Promise<void> => {
+  async function handleKlasseDeleteCloseWrapper(): Promise<void> {
+    klasseToDelete.value = null;
     await reloadData(klassenListFilter.value);
-  };
+  }
 
   function navigateToKlassenDetails(_$event: PointerEvent, { item }: { item: Organisation }): void {
     router.push({ name: 'klasse-details', params: { id: item.id } });
@@ -400,18 +404,30 @@
             </div>
           </template>
           <template #[`item.actions`]="{ item }">
-            <KlasseDelete
-              :klassenname="item.name"
-              :klassen-id="item.id"
-              :schulname="item.schuleDetails ?? ''"
-              :error-code="organisationStore.errorCode"
-              :use-icon-activator="true"
-              :is-loading="organisationStore.loading"
-              @on-delete-klasse="deleteKlasse(item.id)"
-              @on-close="handleKlasseDeleteClose"
+            <v-icon
+              icon="mdi-delete"
+              size="small"
+              @click.stop="
+                () => {
+                  klasseToDelete = item;
+                  isDeleteDialogOpen = true;
+                }
+              "
             />
           </template>
         </ResultTable>
+        <KlasseDelete
+          v-if="klasseToDelete"
+          v-model="isDeleteDialogOpen"
+          :klassenname="klasseToDelete.name"
+          :klassen-id="klasseToDelete.id"
+          :schulname="klasseToDelete.schuleDetails ?? ''"
+          :error-code="organisationStore.errorCode"
+          :is-loading="organisationStore.loading"
+          :use-icon-activator="false"
+          @on-delete-klasse="deleteKlasse"
+          @on-close="handleKlasseDeleteCloseWrapper"
+        />
       </template>
     </LayoutCard>
   </div>

--- a/src/views/admin/organisationen/KlassenManagementView.vue
+++ b/src/views/admin/organisationen/KlassenManagementView.vue
@@ -405,6 +405,7 @@
           </template>
           <template #[`item.actions`]="{ item }">
             <v-icon
+              data-testid="open-klasse-delete-dialog-icon"
               icon="mdi-delete"
               size="small"
               @click.stop="

--- a/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
+++ b/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
@@ -165,14 +165,14 @@
     });
   }
 
-  const handleAlertClose = async (): Promise<void> => {
+  const handleAlertCloseServiceProvider = async (): Promise<void> => {
     isDeleteDialogOpen.value = false;
     serviceProviderToDelete.value = null;
     serviceProviderStore.errorCode = '';
     await reloadData();
   };
 
-  async function onDelete(id: string): Promise<void> {
+  async function onDeleteServiceProvider(id: string): Promise<void> {
     await serviceProviderStore.deleteServiceProvider(id);
     cachedServiceProviderId.value = id;
   }
@@ -219,7 +219,7 @@
     :header-hover-text="organisationStore.currentOrganisation?.name"
   >
     <SpshAlert
-      :button-action="handleAlertClose"
+      :button-action="handleAlertCloseServiceProvider"
       :button-text="t('nav.backToList')"
       :closable="false"
       data-test-id-prefix="service-provider-management-by-schule-error"
@@ -351,7 +351,7 @@
         :is-loading="serviceProviderStore.loading"
         :service-provider-id="serviceProviderToDelete.id"
         :service-provider-name="serviceProviderToDelete.name"
-        @on-delete-service-provider="onDelete"
+        @on-delete-service-provider="onDeleteServiceProvider"
         @on-close="onCloseDeleteDialogWrapper"
       />
     </template>

--- a/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
+++ b/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
@@ -54,6 +54,8 @@
   } = useAutoselectedSchule([RollenSystemRecht.RollenErweitern]);
 
   const cachedServiceProviderId: Ref<string | null> = ref(null);
+  const serviceProviderToDelete: Ref<ServiceProviderRow | null> = ref(null);
+  const isDeleteDialogOpen: Ref<boolean> = ref(false);
 
   const headers: Headers = [
     { title: t('angebot.kategorie'), key: 'kategorie', align: 'start' },
@@ -173,18 +175,24 @@
     cachedServiceProviderId.value = id;
   }
 
-  async function onCloseDeleteDialog(successful: boolean): Promise<void> {
+  async function onCloseDeleteDialogWrapper(successful: boolean): Promise<void> {
+    isDeleteDialogOpen.value = false;
+
     if (!successful) {
       serviceProviderStore.errorCode = '';
+      serviceProviderToDelete.value = null;
       return;
     }
+
     serviceProviderStore.manageableServiceProvidersForOrganisation =
       serviceProviderStore.manageableServiceProvidersForOrganisation.filter(
         (sp: ManageableServiceProviderListEntry) => sp.id !== cachedServiceProviderId.value,
       );
-    await reloadData();
-  }
 
+    await reloadData();
+
+    serviceProviderToDelete.value = null;
+  }
   onBeforeRouteLeave(() => {
     serviceProviderStore.errorCode = '';
     organisationStore.errorCode = '';
@@ -312,14 +320,17 @@
         "
       >
         <template #[`item.actions`]="{ item }: { item: ServiceProviderRow }">
-          <ServiceProviderDelete
+          <v-icon
             v-if="item.isDeleteAuthorized"
-            :error-code="serviceProviderStore.errorCode"
-            :is-loading="serviceProviderStore.loading"
-            :service-provider-id="item.id"
-            :service-provider-name="item.name"
-            @on-delete-service-provider="onDelete"
-            @on-close="onCloseDeleteDialog"
+            icon="mdi-delete"
+            size="small"
+            data-testid="open-service-provider-delete-dialog-icon"
+            @click.stop="
+              () => {
+                serviceProviderToDelete = item;
+                isDeleteDialogOpen = true;
+              }
+            "
           />
         </template>
         <template v-slot:[`item.rollenerweiterungen`]="{ item }">
@@ -331,6 +342,16 @@
           </div>
         </template>
       </ResultTable>
+      <ServiceProviderDelete
+        v-if="serviceProviderToDelete"
+        v-model="isDeleteDialogOpen"
+        :error-code="serviceProviderStore.errorCode"
+        :is-loading="serviceProviderStore.loading"
+        :service-provider-id="serviceProviderToDelete.id"
+        :service-provider-name="serviceProviderToDelete.name"
+        @on-delete-service-provider="onDelete"
+        @on-close="onCloseDeleteDialogWrapper"
+      />
     </template>
   </LayoutCard>
 </template>

--- a/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
+++ b/src/views/admin/service-provider/ServiceProviderManagementBySchuleView.vue
@@ -166,6 +166,8 @@
   }
 
   const handleAlertClose = async (): Promise<void> => {
+    isDeleteDialogOpen.value = false;
+    serviceProviderToDelete.value = null;
     serviceProviderStore.errorCode = '';
     await reloadData();
   };
@@ -343,7 +345,7 @@
         </template>
       </ResultTable>
       <ServiceProviderDelete
-        v-if="serviceProviderToDelete"
+        v-if="serviceProviderToDelete && serviceProviderStore.errorCode === ''"
         v-model="isDeleteDialogOpen"
         :error-code="serviceProviderStore.errorCode"
         :is-loading="serviceProviderStore.loading"

--- a/src/views/admin/service-provider/ServiceProviderManagementView.vue
+++ b/src/views/admin/service-provider/ServiceProviderManagementView.vue
@@ -33,6 +33,9 @@
 
   const cachedServiceProviderId: Ref<string | null> = ref(null);
 
+  const serviceProviderToDelete: Ref<ServiceProviderRow | null> = ref(null);
+  const isDeleteDialogOpen: Ref<boolean, boolean> = ref(false);
+
   const errorTitle: ComputedRef<string> = computed(() => {
     if (!serviceProviderStore.errorCode) {
       return '';
@@ -85,15 +88,22 @@
     cachedServiceProviderId.value = id;
   }
 
-  async function onCloseDeleteDialog(successful: boolean): Promise<void> {
+  async function onCloseDeleteDialogWrapper(successful: boolean): Promise<void> {
+    isDeleteDialogOpen.value = false;
+
     if (!successful) {
       serviceProviderStore.errorCode = '';
+      serviceProviderToDelete.value = null;
       return;
     }
+
     serviceProviderStore.manageableServiceProviders = serviceProviderStore.manageableServiceProviders.filter(
       (sp: ManageableServiceProviderListEntry) => sp.id !== cachedServiceProviderId.value,
     );
+
     await reloadData();
+
+    serviceProviderToDelete.value = null;
   }
 
   const items: ComputedRef<ServiceProviderRow[]> = computed(() => {
@@ -166,16 +176,29 @@
         </div>
       </template>
       <template #[`item.actions`]="{ item }: { item: ServiceProviderRow }">
-        <ServiceProviderDelete
+        <v-icon
           v-if="item.isDeleteAuthorized"
-          :error-code="serviceProviderStore.errorCode"
-          :is-loading="serviceProviderStore.loading"
-          :service-provider-id="item.id"
-          :service-provider-name="item.name"
-          @on-delete-service-provider="onDelete"
-          @on-close="onCloseDeleteDialog"
+          icon="mdi-delete"
+          size="small"
+          data-testid="open-service-provider-delete-dialog-icon"
+          @click.stop="
+            () => {
+              serviceProviderToDelete = item;
+              isDeleteDialogOpen = true;
+            }
+          "
         />
       </template>
     </ResultTable>
+    <ServiceProviderDelete
+      v-if="serviceProviderToDelete"
+      v-model="isDeleteDialogOpen"
+      :error-code="serviceProviderStore.errorCode"
+      :is-loading="serviceProviderStore.loading"
+      :service-provider-id="serviceProviderToDelete.id"
+      :service-provider-name="serviceProviderToDelete.name"
+      @on-delete-service-provider="onDelete"
+      @on-close="onCloseDeleteDialogWrapper"
+    />
   </LayoutCard>
 </template>

--- a/src/views/admin/service-provider/ServiceProviderManagementView.vue
+++ b/src/views/admin/service-provider/ServiceProviderManagementView.vue
@@ -79,6 +79,8 @@
   }
 
   const handleAlertClose = async (): Promise<void> => {
+    isDeleteDialogOpen.value = false;
+    serviceProviderToDelete.value = null;
     serviceProviderStore.errorCode = '';
     await reloadData();
   };
@@ -191,7 +193,7 @@
       </template>
     </ResultTable>
     <ServiceProviderDelete
-      v-if="serviceProviderToDelete"
+      v-if="serviceProviderToDelete && serviceProviderStore.errorCode === ''"
       v-model="isDeleteDialogOpen"
       :error-code="serviceProviderStore.errorCode"
       :is-loading="serviceProviderStore.loading"


### PR DESCRIPTION
# Description

**Removed internal activators from delete dialog components. Dialogs are now controlled by the parent to decouple them from table row lifecycle and prevent them from being destroyed during table re-renders (e.g. loading states).**

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.